### PR TITLE
Fix/installation conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Changelog
 
+- 2025-05-23 [dch4o](mailto:dohoon.cho@nearthlab.com)
+  - Add `--symlink-install` and `packages-up-to` flag in `./build.sh` to prevent installation conflict 
 - 2025-04-01 [junwoopark](mailto:junwoo.park@nearthlab.com)
   - Convert acceleration output unit: from `g` to `m/s^2`
 

--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,7 @@ if [ $ROS_VERSION = ${VERSION_ROS1} ]; then
     catkin_make -DROS_EDITION=${VERSION_ROS1}
 elif [ $ROS_VERSION = ${VERSION_ROS2} ]; then
     cd ../../
-    colcon build --cmake-args -DROS_EDITION=${VERSION_ROS2} -DHUMBLE_ROS=${ROS_HUMBLE}
+    colcon build --cmake-args -DROS_EDITION=${VERSION_ROS2} -DHUMBLE_ROS=${ROS_HUMBLE} --symlink-install --packages-up-to livox_ros_driver2
 fi
 popd > /dev/null
 


### PR DESCRIPTION
`ids_mmu_workspace/src`에 livox_ros_driver2를 위치해놓고 빌드할 때 
`./build.sh humble` 이런식으로 하면 colcon build를 결국 workspace root에서 진행하게 되어 symlink-install 플래그와 충돌하는 경우가 있었습니다.
따라서 build.sh 파일에 colcon build 하는 라인에 해당 플래그들을 추가하여 build conflict가 발생하지 않도록 수정하였습니다.